### PR TITLE
[hotfix] fix wrong signal image

### DIFF
--- a/src/features/sidebar/Meeting.js
+++ b/src/features/sidebar/Meeting.js
@@ -126,7 +126,7 @@ const Meeting = React.forwardRef(function Meeting(
             <div className="image-container">
               <img
                 className="dot"
-                src={meeting.isLive ? greenDot : redDot}
+                src={signalImage}
                 alt="meeting not ready icon"
               />
             </div>


### PR DESCRIPTION
## 칸반 카드번호
none
## 칸반 카드 링크
none
## 구현내용
- 미팅 준비 신호이미지가 잘못 출력되는 버그를 고쳤습니다. 